### PR TITLE
Add basic Vercel deployment scaffolding

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Praxis Elearning</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+
+function App() {
+  return <h1>Hello, Praxis</h1>;
+}
+
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);

--- a/server/app.ts
+++ b/server/app.ts
@@ -1,0 +1,12 @@
+import express from 'express';
+import path from 'path';
+
+const app = express();
+
+app.use(express.static(path.join(__dirname, 'public')));
+
+app.get('/api/hello', (_req, res) => {
+  res.json({ message: 'Hello from Vercel' });
+});
+
+export default app;

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,0 +1,13 @@
+import { createServer } from 'http';
+import app from './app';
+
+const server = createServer(app);
+const port = Number(process.env.PORT) || 5000;
+
+if (process.env.NODE_ENV !== 'production') {
+  server.listen(port, () => {
+    console.log(`Server running on http://localhost:${port}`);
+  });
+}
+
+export default server;

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "version": 2,
+  "builds": [
+    { "src": "package.json", "use": "@vercel/node" }
+  ],
+  "routes": [
+    { "src": "/(.*)", "dest": "server/index.ts" }
+  ]
+}


### PR DESCRIPTION
## Summary
- create a minimal Express server with `server/app.ts` and `server/index.ts`
- add a minimal React client for `vite` build
- configure `vercel.json` for Node runtime

## Testing
- `npm run check` *(fails: No inputs were found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68417f8bce0c832393564d649a9a4fd9