### PR TITLE
Fix Vercel deployment

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -1,13 +1,20 @@
 import { createServer } from 'http';
+import type { VercelRequest, VercelResponse } from '@vercel/node';
 import app from './app';
 
-const server = createServer(app);
-const port = Number(process.env.PORT) || 5000;
+// Run a local HTTP server when not deployed on Vercel.
+if (!process.env.VERCEL) {
+  const server = createServer(app);
+  const port = Number(process.env.PORT) || 5000;
 
-server.listen(port, () => {
-  if (process.env.NODE_ENV !== 'test') {
-    console.log(`Server running on http://localhost:${port}`);
-  }
-});
+  server.listen(port, () => {
+    if (process.env.NODE_ENV !== 'test') {
+      console.log(`Server running on http://localhost:${port}`);
+    }
+  });
+}
 
-export default server;
+// Export a handler for Vercel serverless functions.
+export default function handler(req: VercelRequest, res: VercelResponse) {
+  return app(req, res);
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "builds": [
-    { "src": "package.json", "use": "@vercel/node" }
+    { "src": "server/index.ts", "use": "@vercel/node" }
   ],
   "routes": [
     { "src": "/(.*)", "dest": "server/index.ts" }


### PR DESCRIPTION
## Summary
- update Vercel config to use the server entry
- export a Vercel-compatible handler

## Testing
- `npm run check` *(fails: node_modules/csstype/index.d.ts error)*

------
https://chatgpt.com/codex/tasks/task_e_6841908cc9148323b97ad8bf62066acc