### PR TITLE
Fix ESM import for Vercel

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -1,6 +1,9 @@
 import { createServer } from 'http';
 import type { VercelRequest, VercelResponse } from '@vercel/node';
-import app from './app';
+// Import the compiled JavaScript file explicitly so that Node's ESM
+// resolver can locate the file both locally and in the Vercel
+// serverless environment.
+import app from './app.js';
 
 // Run a local HTTP server when not deployed on Vercel.
 if (!process.env.VERCEL) {


### PR DESCRIPTION
## Summary
- reference the compiled `app.js` in the server

## Testing
- `npm install`
- `npm run check` *(fails: Cannot find module '@vercel/node')*

------
https://chatgpt.com/codex/tasks/task_e_684192a63f44832382ad495fdc23e3ac