### PR TITLE
Fix 404 by serving default index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 node_modules
 dist
 .DS_Store
-server/public
 vite.config.ts.*
 *.tar.gz

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Praxis Elearning</title>
+  </head>
+  <body>
+    <h1>Hello, Praxis</h1>
+    <p>If you are seeing this page on Vercel, the deployment succeeded.</p>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- track the server/public directory
- add a simple static index page to avoid 404s

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6841956c44b48323bb5b886815d92550