### PR TITLE
Fix imports and server options

### DIFF
--- a/client/src/pages/Landing.tsx
+++ b/client/src/pages/Landing.tsx
@@ -1,5 +1,10 @@
-import { Link } from "react-router-dom";
-import { AcademicCapIcon, LightBulbIcon, RocketLaunchIcon, CurrencyDollarIcon } from "react-icons/hi2";
+import { Link } from "wouter";
+import {
+  HiAcademicCap as AcademicCapIcon,
+  HiLightBulb as LightBulbIcon,
+  HiRocketLaunch as RocketLaunchIcon,
+  HiCurrencyDollar as CurrencyDollarIcon,
+} from "react-icons/hi2";
 import { Check, X, Star } from "lucide-react";
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { Button } from "@/components/ui/button";

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -24,7 +24,7 @@ export async function setupVite(app: Express, server: Server) {
     middlewareMode: true,
     hmr: { server },
     allowedHosts: true,
-  };
+  } as const;
 
   const vite = await createViteServer({
     ...viteConfig,


### PR DESCRIPTION
## Summary
- use Wouter link component on landing page
- import correct `hi2` icon names
- fix Vite server options typing

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6841c348f93883239ef2ddbdab812cef