### PR TITLE
feat(db): add User model + helper

### DIFF
--- a/lib/db/client.ts
+++ b/lib/db/client.ts
@@ -1,0 +1,11 @@
+import { PrismaClient } from '@prisma/client'
+
+const globalForPrisma = globalThis as unknown as { prisma?: PrismaClient }
+
+export const prisma = globalForPrisma.prisma ?? new PrismaClient()
+
+if (process.env.NODE_ENV !== 'production') {
+  globalForPrisma.prisma = prisma
+}
+
+export default prisma

--- a/lib/db/user.ts
+++ b/lib/db/user.ts
@@ -1,0 +1,17 @@
+import { prisma } from './client'
+
+export function createUser(email: string, hashedPassword?: string) {
+  return prisma.user.create({
+    data: {
+      email,
+      hashedPassword,
+    },
+  })
+}
+
+export function getUserByEmail(email: string) {
+  return prisma.user.findUnique({
+    where: { email },
+  })
+}
+

--- a/package.json
+++ b/package.json
@@ -74,7 +74,8 @@
     "wouter": "^3.3.5",
     "ws": "^8.18.0",
     "zod": "^3.24.2",
-    "zod-validation-error": "^3.4.0"
+    "zod-validation-error": "^3.4.0",
+    "@prisma/client": "^5.13.0"
   },
   "devDependencies": {
     "@replit/vite-plugin-cartographer": "^0.2.7",
@@ -99,7 +100,8 @@
     "tailwindcss": "^3.4.17",
     "tsx": "^4.19.1",
     "typescript": "5.6.3",
-    "vite": "^5.4.14"
+    "vite": "^5.4.14",
+    "prisma": "^5.13.0"
   },
   "optionalDependencies": {
     "bufferutil": "^4.0.8"

--- a/prisma/migrations/20250606103754_add_user_table/migration.sql
+++ b/prisma/migrations/20250606103754_add_user_table/migration.sql
@@ -1,0 +1,12 @@
+-- CreateTable
+CREATE TABLE "User" (
+    "id" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "hashedPassword" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "User_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,16 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id            String   @id @default(cuid())
+  email         String   @unique
+  hashedPassword String?
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,23 +1,44 @@
 {
-  "include": ["client/src/**/*", "shared/**/*", "server/**/*"],
-  "exclude": ["node_modules", "build", "dist", "**/*.test.ts"],
+  "include": [
+    "client/src/**/*",
+    "shared/**/*",
+    "server/**/*",
+    "lib/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "build",
+    "dist",
+    "**/*.test.ts"
+  ],
   "compilerOptions": {
     "incremental": true,
     "tsBuildInfoFile": "./node_modules/typescript/tsbuildinfo",
     "noEmit": true,
     "module": "ESNext",
     "strict": true,
-    "lib": ["esnext", "dom", "dom.iterable"],
+    "lib": [
+      "esnext",
+      "dom",
+      "dom.iterable"
+    ],
     "jsx": "preserve",
     "esModuleInterop": true,
     "skipLibCheck": true,
     "allowImportingTsExtensions": true,
     "moduleResolution": "bundler",
     "baseUrl": ".",
-    "types": ["node", "vite/client"],
+    "types": [
+      "node",
+      "vite/client"
+    ],
     "paths": {
-      "@/*": ["./client/src/*"],
-      "@shared/*": ["./shared/*"]
+      "@/*": [
+        "./client/src/*"
+      ],
+      "@shared/*": [
+        "./shared/*"
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary
- create prisma schema and migration for `User`
- add typed db helper for user operations
- wire Prisma client helper
- include lib in tsconfig and add Prisma deps

## Testing
- `PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 npx -y prisma migrate dev --name add_user_table --create-only` *(fails: 403 Forbidden)*
- `PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 npx -y prisma generate` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6842c43f61b483239bd3924e44d63e64