### PR TITLE
Add AuthForm and SessionProvider

### DIFF
--- a/components/AuthForm.tsx
+++ b/components/AuthForm.tsx
@@ -1,0 +1,38 @@
+import { useForm } from "react-hook-form";
+import { signIn } from "next-auth/react";
+import { useState } from "react";
+
+interface Inputs {
+  email: string;
+  password: string;
+}
+
+export default function AuthForm({ callbackUrl = "/" }: { callbackUrl?: string }) {
+  const { register, handleSubmit, formState: { errors } } = useForm<Inputs>();
+  const [loading, setLoading] = useState(false);
+
+  async function onSubmit(data: Inputs) {
+    setLoading(true);
+    const res = await signIn("credentials", { ...data, callbackUrl, redirect: true });
+    if (res?.error) alert("Invalid credentials");
+    setLoading(false);
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="w-full space-y-4">
+      <div>
+        <label className="label">Email</label>
+        <input {...register("email", { required: true })}
+               className="input" type="email" autoComplete="email" />
+        {errors.email && <p className="text-red-500 text-sm">Email required</p>}
+      </div>
+      <div>
+        <label className="label">Password</label>
+        <input {...register("password", { required: true })}
+               className="input" type="password" autoComplete="current-password" />
+      </div>
+      <button disabled={loading}
+              className="btn-primary w-full">{loading ? "…" : "Sign in"}</button>
+    </form>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "react": "^18.3.1",
     "react-day-picker": "^8.10.1",
     "react-dom": "^18.3.1",
-    "react-hook-form": "^7.55.0",
+    "react-hook-form": "^7.51.2",
     "react-icons": "^5.4.0",
     "react-resizable-panels": "^2.1.7",
     "recharts": "^2.15.2",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,0 +1,10 @@
+import type { AppProps } from 'next/app';
+import { SessionProvider } from "next-auth/react";
+
+export default function MyApp({ Component, pageProps: { session, ...pageProps } }: AppProps) {
+  return (
+    <SessionProvider session={session as any}>
+      <Component {...pageProps} />
+    </SessionProvider>
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -177,7 +177,7 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
       react-hook-form:
-        specifier: ^7.55.0
+        specifier: ^7.51.2
         version: 7.57.0(react@18.3.1)
       react-icons:
         specifier: ^5.4.0


### PR DESCRIPTION
## Summary
- downgrade `react-hook-form` to ^7.51.2
- wrap application with `SessionProvider`
- add `AuthForm` component for credential login

## Testing
- `pnpm run check` *(fails: Cannot find module 'bcryptjs', cannot find module 'nanoid')*

------
https://chatgpt.com/codex/tasks/task_e_6842cb0350648323b341d60a697bbea3