### PR TITLE
Fix pg import for ESM

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -1,7 +1,8 @@
 import express, { type Request, Response, NextFunction } from "express";
 import session from "express-session";
 import connectPgSimple from "connect-pg-simple";
-import { Pool } from "pg";
+import pg from "pg";
+const { Pool } = pg;
 import passport, { ensureAuth } from "./auth";
 import { storage } from "./storage";
 import bcrypt from "bcryptjs";


### PR DESCRIPTION
## Summary
- resolve ESM import mismatch for `pg` by using default import and destructuring Pool

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node' and 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_6842d34840f88323882be9d0e6187464