### PR TITLE
Fix login form body parsing

### DIFF
--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import { useLocation } from "wouter";
-import { apiRequest } from "@/lib/queryClient";
 
 export default function Login() {
   const [, navigate] = useLocation();
@@ -9,8 +8,18 @@ export default function Login() {
 
   async function onSubmit(e: React.FormEvent) {
     e.preventDefault();
-    await apiRequest("POST", "/api/auth/login", { email, password });
-    navigate("/dashboard");
+    const fd = new FormData();
+    fd.append("username", email);
+    fd.append("password", password);
+    const res = await fetch("/api/auth/login", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams(fd as any),
+      credentials: "include",
+    });
+    if (res.ok) {
+      navigate("/dashboard");
+    }
   }
 
   return (

--- a/server/index.ts
+++ b/server/index.ts
@@ -11,7 +11,7 @@ import { setupVite, serveStatic, log } from "./vite";
 
 const app = express();
 app.use(express.json());
-app.use(express.urlencoded({ extended: false }));
+app.use(express.urlencoded({ extended: true }));
 
 const PgSession = connectPgSimple(session);
 app.use(


### PR DESCRIPTION
## Summary
- parse urlencoded bodies on Express app
- submit form-encoded credentials from the login page

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6842dba939848323b3fa67aa95f854ef