### PR TITLE
fix(env): load .env.local first

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,6 @@ SESSION_SECRET=
 
 # Postgres connection string used by Prisma
 DATABASE_URL=
+
+# Primary Postgres connection string (Prisma + Passport)
+DATABASE_URL=

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "cmdk": "^1.1.1",
         "connect-pg-simple": "^10.0.0",
         "date-fns": "^3.6.0",
-        "dotenv": "^16.5.0",
+        "dotenv": "^16.4.0",
         "drizzle-orm": "^0.39.1",
         "drizzle-zod": "^0.7.0",
         "embla-carousel-react": "^8.6.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "cmdk": "^1.1.1",
     "connect-pg-simple": "^10.0.0",
     "date-fns": "^3.6.0",
-    "dotenv": "^16.5.0",
+    "dotenv": "^16.4.0",
     "drizzle-orm": "^0.39.1",
     "drizzle-zod": "^0.7.0",
     "embla-carousel-react": "^8.6.0",

--- a/server/env.ts
+++ b/server/env.ts
@@ -1,0 +1,6 @@
+import { config } from "dotenv";
+config({ path: [".env.local", ".env"] });
+if (!process.env.DATABASE_URL) {
+  console.error("[startup] \u274C DATABASE_URL is missing. Check .env.local");
+  process.exit(1);
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,4 +1,4 @@
-import "dotenv/config";
+import "./env"; // MUST be first import
 import express, { type Request, Response, NextFunction } from "express";
 import session from "express-session";
 import connectPgSimple from "connect-pg-simple";


### PR DESCRIPTION
## Summary
- ensure dotenv version 16.4.0
- load `.env.local` before `.env` in new `server/env.ts`
- use the new env loader in `server/index.ts`
- document DATABASE_URL in `.env.example`

## Testing
- `npm run check`
- `npm run dev` *(fails: DATABASE_URL is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68430352661c83239ccf347fdd82a92b