### PR TITLE
Fix schema migration and seeding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# praxis_replit
+
+## Getting started
+
+1. Copy .env.example \u2192 .env and set DATABASE_URL
+2. pnpm install
+3. pnpm run db:migrate   # creates/updates tables
+4. pnpm run dev

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
-    "db:push": "drizzle-kit push"
+    "db:push": "drizzle-kit push",
+    "db:migrate": "npx prisma migrate dev --name sync_schema"
   },
   "prisma": {
     "seed": "tsx prisma/seed.ts"

--- a/prisma/migrations/20250606154108_add_hashed_password/migration.sql
+++ b/prisma/migrations/20250606154108_add_hashed_password/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN "hashedPassword" TEXT;

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -4,21 +4,15 @@ import bcrypt from 'bcryptjs';
 const prisma = new PrismaClient();
 
 async function main() {
-  const email = 'andr0476@outlook.com';
-  const password = 'seedpass';
-
-  const hashedPassword = await bcrypt.hash(password, 10);
+  const hashedPassword = await bcrypt.hash('Ra52w102$', 10);
 
   await prisma.user.upsert({
-    where: { email },
-    update: {},
-    create: {
-      email,
-      hashedPassword,
-    },
+    where: { email: 'andr0476@outlook.com' },
+    update: { hashedPassword },
+    create: { email: 'andr0476@outlook.com', hashedPassword },
   });
 
-  console.log(`✅ Seeded user: ${email}`);
+  console.log(`✅ Seeded user: andr0476@outlook.com`);
 }
 
 main()


### PR DESCRIPTION
## Summary
- add db:migrate script
- add migration for hashedPassword column
- ensure seed script always provides hashed password
- document setup instructions

## Testing
- `pnpm run check`
- `pnpm run db:migrate` *(fails: Error: Failed to fetch the engine file)*
- `npx prisma db seed` *(fails: Error: Failed to fetch the engine file)*

------
https://chatgpt.com/codex/tasks/task_e_68430a2df2bc832380e6fe9f16d6b8a1