### PR TITLE
fix(db): add hashedPassword migration & migrate script

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,8 @@
 
 1. Copy .env.example \u2192 .env and set DATABASE_URL
 2. pnpm install
-3. pnpm run db:migrate   # creates/updates tables
+3. pnpm run db:migrate   # syncs schema → database
 4. pnpm run dev
+
+pnpm run db:migrate   # syncs schema → database
+pnpm run dev

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
     "db:push": "drizzle-kit push",
-    "db:migrate": "npx prisma migrate dev --name sync_schema"
+    "db:migrate": "npx prisma migrate dev"
   },
   "prisma": {
     "seed": "tsx prisma/seed.ts"

--- a/prisma/migrations/20250606161539_add_hashed_password/migration.sql
+++ b/prisma/migrations/20250606161539_add_hashed_password/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN "hashedPassword" TEXT;


### PR DESCRIPTION
## Summary
- migrate `hashedPassword` into the DB
- update migrate script
- document how to migrate and start server

## Testing
- `PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 pnpm run db:migrate` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6843138eb59c8323a21129962935e6b6