### PR TITLE
Fix missing hashed password column

### DIFF
--- a/prisma/migrations/20250606170100_add_hashed_password_map/migration.sql
+++ b/prisma/migrations/20250606170100_add_hashed_password_map/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN IF NOT EXISTS "hashed_password" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,7 +10,7 @@ datasource db {
 model User {
   id            String   @id @default(cuid())
   email         String   @unique
-  hashedPassword String?
+  hashedPassword String? @map("hashed_password")
   createdAt     DateTime @default(now())
   updatedAt     DateTime @updatedAt
 }


### PR DESCRIPTION
## Summary
- map `User.hashedPassword` to the existing `hashed_password` column
- add a migration creating the column if missing

## Testing
- `npx prisma migrate dev --name add_hashed_password` *(fails: 403 Forbidden fetching engine)*
- `npx prisma generate` *(fails: 403 Forbidden fetching engine)*
- `npx prisma migrate status` *(fails: 403 Forbidden fetching engine)*
- `npm run dev` *(fails: DATABASE_URL is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68431add187483238ab887c7c7511b78