### PR TITLE
Add sanity script and demo user seeding

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
     "db:push": "drizzle-kit push",
-    "db:migrate": "npx prisma migrate dev"
+    "db:migrate": "npx prisma migrate dev",
+    "sanity": "tsx scripts/sanity.ts",
+    "test-login": "tsx scripts/testLogin.ts"
   },
   "prisma": {
     "seed": "tsx prisma/seed.ts"

--- a/scripts/sanity.ts
+++ b/scripts/sanity.ts
@@ -1,0 +1,7 @@
+import { PrismaClient } from '@prisma/client';
+(async () => {
+  const prisma = new PrismaClient();
+  console.log('[SANITY] DATABASE_URL =', process.env.DATABASE_URL);
+  console.log('[SANITY] Users in DB:', await prisma.user.findMany());
+  await prisma.$disconnect();
+})();

--- a/scripts/testLogin.ts
+++ b/scripts/testLogin.ts
@@ -1,0 +1,12 @@
+import fetch from 'node-fetch';
+(async () => {
+  const res = await fetch('http://localhost:5000/api/auth/login', {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      email: 'andr0476@outlook.com',
+      password: 'Ra52w102$',
+    }),
+  });
+  console.log('[TEST] Status:', res.status, 'Body:', await res.text());
+})();

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -4,13 +4,32 @@ import { Strategy as LocalStrategy } from "passport-local";
 import type { Request, Response, NextFunction } from "express";
 import { db } from "./db";
 
+(async () => {
+  const email = 'andr0476@outlook.com';
+  const prisma = (global as any).prisma as import('@prisma/client').PrismaClient;
+  const haveUser = await prisma.user.findUnique({ where: { email } });
+  if (!haveUser) {
+    const bcrypt = await import('bcryptjs');
+    await prisma.user.create({
+      data: {
+        email: email.toLowerCase(),
+        hashedPassword: await bcrypt.hash('Ra52w102$', 10),
+      },
+    });
+    console.log('[BOOT] Demo user inserted');
+  } else {
+    console.log('[BOOT] Demo user already present');
+  }
+})();
+
 passport.use(
   new LocalStrategy(
     { usernameField: "email" },
     async (email, password, done) => {
       try {
+        const cleanEmail = email.trim().toLowerCase();
         const user = await db.user.findUnique({
-          where: { email: email.toLowerCase().trim() },
+          where: { email: cleanEmail },
         });
         if (!user) return done(null, false, { message: "No user" });
 

--- a/server/db.ts
+++ b/server/db.ts
@@ -1,4 +1,9 @@
 import "dotenv/config";
 import { PrismaClient } from "@prisma/client";
 
-export const db = new PrismaClient();
+const globalForPrisma = globalThis as unknown as { prisma?: PrismaClient };
+export const db = globalForPrisma.prisma ?? new PrismaClient();
+
+if (process.env.NODE_ENV !== "production") {
+  globalForPrisma.prisma = db;
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -10,6 +10,8 @@ import bcrypt from "bcryptjs";
 import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";
 
+console.log('[API] DATABASE_URL =', process.env.DATABASE_URL);
+
 const app = express();
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));


### PR DESCRIPTION
## Summary
- log the DATABASE_URL on server startup
- provide sanity script to list users
- auto-seed demo user at boot if missing
- normalize email for login
- share Prisma client instance
- add e2e login test script

## Testing
- `npm run sanity` *(fails: @prisma/client did not initialize yet)*
- `npm run dev` *(fails: @prisma/client did not initialize yet)*
- `npm run test-login` *(fails: Cannot find package 'node-fetch')*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_684346568ee8832397f651d94ebbfbfb