### PR TITLE
Fix bcrypt hash error in auth boot script

### DIFF
--- a/server/auth.ts
+++ b/server/auth.ts
@@ -9,7 +9,6 @@ import { db } from "./db";
   const prisma = (global as any).prisma as import('@prisma/client').PrismaClient;
   const haveUser = await prisma.user.findUnique({ where: { email } });
   if (!haveUser) {
-    const bcrypt = await import('bcryptjs');
     await prisma.user.create({
       data: {
         email: email.toLowerCase(),


### PR DESCRIPTION
## Summary
- fix dynamic `bcrypt` import which produced undefined `hash` function

## Testing
- `npm run check`
- `npm run test-login` *(fails: Cannot find package 'node-fetch')*

------
https://chatgpt.com/codex/tasks/task_e_68434886a5348323954094811e9fb9c4